### PR TITLE
Use milestones to identify month

### DIFF
--- a/src/components/HillFactory.js
+++ b/src/components/HillFactory.js
@@ -35,16 +35,5 @@ export default (x, y, debtPayoffCalendar) => {
     )
   );
 
-  bodies.push(
-    ...milestones.map((milestone) =>
-      Bodies.fromVertices(
-        milestone.x,
-        milestone.y,
-        Vertices.fromPath([0, 0, 1, 0, 1, 1000, 0, 1000].join(' ')),
-        { isStatic: true, collisionFilter: false }
-      )
-    )
-  );
-
   return { bodies, milestones };
 };

--- a/src/components/HillFactory.js
+++ b/src/components/HillFactory.js
@@ -6,14 +6,15 @@ export default (x, y, debtPayoffCalendar) => {
   const segmentLength = 75;
   const segmentHeight = 50;
 
-  const milestones = debtPayoffCalendar.map(
-    (_, index) => x + segmentLength * index
-  );
+  const milestones = debtPayoffCalendar.map((_, index) => ({
+    x: x + segmentLength * index - segmentOverlap * index,
+    y: y + segmentHeight * index - segmentOverlap * index
+  }));
 
-  const bodies = milestones.map((_, index) =>
+  const bodies = milestones.map((milestone, index) =>
     Bodies.fromVertices(
-      x + segmentLength / 2 + index * segmentLength - index * segmentOverlap,
-      y + segmentHeight / 2 + index * segmentHeight - index * segmentOverlap,
+      milestone.x + segmentLength / 2,
+      milestone.y + segmentHeight / 2,
       Vertices.fromPath(
         [
           0,

--- a/src/components/HillFactory.js
+++ b/src/components/HillFactory.js
@@ -3,8 +3,8 @@ import { Bodies, Vertices } from 'matter-js';
 export default (x, y, debtPayoffCalendar) => {
   const colors = ['red', 'green', 'blue'];
   const segmentOverlap = 10;
-  const segmentLength = 300;
-  const segmentHeight = 200;
+  const segmentLength = 200;
+  const segmentHeight = 125;
 
   const milestones = debtPayoffCalendar.map((_, index) => ({
     x: x + segmentLength * index - segmentOverlap * index,

--- a/src/components/HillFactory.js
+++ b/src/components/HillFactory.js
@@ -3,8 +3,8 @@ import { Bodies, Vertices } from 'matter-js';
 export default (x, y, debtPayoffCalendar) => {
   const colors = ['red', 'green', 'blue'];
   const segmentOverlap = 10;
-  const segmentLength = 75;
-  const segmentHeight = 50;
+  const segmentLength = 300;
+  const segmentHeight = 200;
 
   const milestones = debtPayoffCalendar.map((_, index) => ({
     x: x + segmentLength * index - segmentOverlap * index,
@@ -32,6 +32,17 @@ export default (x, y, debtPayoffCalendar) => {
         ].join(' ')
       ),
       { isStatic: true, render: { fillStyle: colors[index % colors.length] } }
+    )
+  );
+
+  bodies.push(
+    ...milestones.map((milestone) =>
+      Bodies.fromVertices(
+        milestone.x,
+        milestone.y,
+        Vertices.fromPath([0, 0, 1, 0, 1, 1000, 0, 1000].join(' ')),
+        { isStatic: true, collisionFilter: false }
+      )
     )
   );
 

--- a/src/components/HillFactory.js
+++ b/src/components/HillFactory.js
@@ -7,8 +7,8 @@ export default (x, y, debtPayoffCalendar) => {
   const segmentHeight = 125;
 
   const milestones = debtPayoffCalendar.map((_, index) => ({
-    x: x + segmentLength * index - segmentOverlap * index,
-    y: y + segmentHeight * index - segmentOverlap * index
+    x: x + (segmentLength - segmentOverlap) * index,
+    y: y + (segmentHeight - segmentOverlap) * index
   }));
 
   const bodies = milestones.map((milestone, index) =>

--- a/src/components/simulator.js
+++ b/src/components/simulator.js
@@ -76,11 +76,12 @@ export const start = () => {
 
   const updateSimulation = () => {
     currentUpdate++;
+    const nextMonthIndex = currentMonthIndex + 1;
 
-    if (currentMonthIndex >= debtPayoffCalendar.length) {
+    if (!debtPayoffCalendar[nextMonthIndex]) {
       Render.stop(render);
       Runner.stop(runner);
-    } else if (currentUpdate >= 60) {
+    } else if (hill.milestones[nextMonthIndex].x <= snowball.bounds.min.x) {
       currentMonthIndex++;
       currentUpdate = 0;
 

--- a/src/components/simulator.js
+++ b/src/components/simulator.js
@@ -16,17 +16,15 @@ import HillFactory from './HillFactory';
 
 window.decomp = decomp;
 
-let currentUpdate = 0;
 let currentMonthIndex = 0;
 let debtPayoffCalendar;
 const snowballStartingSize = 20;
 const startX = 100;
-const startY = 400;
-const monthHillLength = snowballStartingSize * 5;
+const startY = 0;
 
 let spriteScale = 0.02;
 
-const snowball = Bodies.circle(startX, 0, snowballStartingSize, {
+const snowball = Bodies.circle(startX, startY, snowballStartingSize, {
   render: {
     sprite: {
       texture: './images/snowball.png',
@@ -39,7 +37,6 @@ let hill;
 
 const setup = () => {
   debtPayoffCalendar = debtPayoff();
-  const hillSize = monthHillLength * debtPayoffCalendar.length;
 
   hill = HillFactory(50, 300, debtPayoffCalendar);
 };
@@ -75,7 +72,6 @@ export const start = () => {
   };
 
   const updateSimulation = () => {
-    currentUpdate++;
     const nextMonthIndex = currentMonthIndex + 1;
 
     if (!debtPayoffCalendar[nextMonthIndex]) {
@@ -83,7 +79,6 @@ export const start = () => {
       Runner.stop(runner);
     } else if (hill.milestones[nextMonthIndex].x <= snowball.bounds.min.x) {
       currentMonthIndex++;
-      currentUpdate = 0;
 
       const scale = getSnowballScale(debtPayoffCalendar, currentMonthIndex);
       spriteScale *= scale;


### PR DESCRIPTION
This change makes the snowball's current month logic take advantage of the milestones being generated by `HillFactory`.